### PR TITLE
don't send report from xdist workers

### DIFF
--- a/pytest_tinybird/tinybird.py
+++ b/pytest_tinybird/tinybird.py
@@ -35,6 +35,9 @@ class TinybirdReport:
         terminalreporter: TerminalReporter = session.config.pluginmanager.get_plugin(
             "terminalreporter"
         )
+        # special check for pytest-xdist plugin, we do not want to send report for each worker.
+        if hasattr(terminalreporter.config, 'workerinput'):
+            return
         report = []
         for k in terminalreporter.stats:
             for test in terminalreporter.stats[k]:
@@ -60,7 +63,7 @@ class TinybirdReport:
             data=data,
             timeout=REQUEST_TIMEOUT)
         if response.status_code != 202:
-            log.error("Error while uploading to tinybird")
+            log.error("Error while uploading to tinybird %s", response.status_code)
 
     @pytest.hookimpl(trylast=True)
     def pytest_sessionfinish(self, session: Session, exitstatus: Union[int, ExitCode]):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,5 +2,6 @@ flake8==6.0.0
 pylint==2.16.2
 pytest==7.2.1
 requests>=2.28.1
+pytest-xdist==2.5.0
 tox==4.2.8
 

--- a/tests/test_tinybird.py
+++ b/tests/test_tinybird.py
@@ -7,16 +7,21 @@ def test_report_to_tinybird(testdir):
     # create a temporary pytest test module
     testdir.makepyfile("""
         import pytest
+        from random import randint
         def test_passed():
             assert True
-    """)
+        def test_flaky():
+            assert randint(1,10) >=5
+        """)
 
     tinybird_url = os.environ["TINYBIRD_URL"] = 'https://fake-api.tinybird.co'
     datasource_name = os.environ["TINYBIRD_DATASOURCE"] = "test_datasource"
     tinybird_token = os.environ["TINYBIRD_TOKEN"] = 'test_token'
 
     with mock.patch('requests.post') as mock_post:
+        mock_post.return_value.status_code = 202
         testdir.runpytest(
+            "-n 2",
             '--report-to-tinybird',
             '-vvv'
         )


### PR DESCRIPTION
When using xdist-workers we don't have to send report from workers. Otherwise we get duplicated entries