### PR TITLE
Add branch name to test reports

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,6 +27,7 @@ jobs:
           TINYBIRD_URL: https://api.tinybird.co
           TINYBIRD_DATASOURCE: ci_tests
           TINYBIRD_TOKEN: ${{ secrets.TINYBIRD_TOKEN }}
+          CI_COMMIT_BRANCH: ${{ github.ref_name }}
           CI_COMMIT_SHA: ${{ github.sha }}
           CI_JOB_ID: ${{ github.job }}-${{ matrix.python-version }}
           CI_JOB_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/pytest_tinybird/tinybird.py
+++ b/pytest_tinybird/tinybird.py
@@ -22,6 +22,7 @@ class TinybirdReport:
         self.datasource_name = os.environ.get("TINYBIRD_DATASOURCE")
         self.token = os.environ.get("TINYBIRD_TOKEN")
         self.url = f"{self.base_url}/v0/events?name={self.datasource_name}&token={self.token}"
+        self.branch = os.environ.get('CI_MERGE_REQUEST_SOURCE_BRANCH_NAME', os.environ.get('CI_COMMIT_BRANCH', 'ci_commit_branch_unknown'))
         self.commit = os.environ.get('CI_COMMIT_SHA', 'ci_commit_sha_unknown')
         self.job_id = os.environ.get('CI_JOB_ID', 'ci_job_id_unknown')
         self.job_url = os.environ.get('CI_JOB_URL', 'job_url_unknown')

--- a/pytest_tinybird/tinybird.py
+++ b/pytest_tinybird/tinybird.py
@@ -22,11 +22,14 @@ class TinybirdReport:
         self.datasource_name = os.environ.get("TINYBIRD_DATASOURCE")
         self.token = os.environ.get("TINYBIRD_TOKEN")
         self.url = f"{self.base_url}/v0/events?name={self.datasource_name}&token={self.token}"
-        self.branch = os.environ.get('CI_MERGE_REQUEST_SOURCE_BRANCH_NAME', os.environ.get('CI_COMMIT_BRANCH', 'ci_commit_branch_unknown'))
         self.commit = os.environ.get('CI_COMMIT_SHA', 'ci_commit_sha_unknown')
         self.job_id = os.environ.get('CI_JOB_ID', 'ci_job_id_unknown')
         self.job_url = os.environ.get('CI_JOB_URL', 'job_url_unknown')
         self.job_name = os.environ.get('CI_JOB_NAME', 'job_name_unknown')
+        self.branch = os.environ.get(
+            'CI_MERGE_REQUEST_SOURCE_BRANCH_NAME',
+            os.environ.get('CI_COMMIT_BRANCH', 'ci_commit_branch_unknown')
+        )
 
     def report(self, session: Session):
         if None in [self.base_url, self.datasource_name, self.token]:
@@ -53,7 +56,8 @@ class TinybirdReport:
                         'test_name': test.head_line,
                         'test_part': test.when,
                         'duration': test.duration,
-                        'outcome': test.outcome
+                        'outcome': test.outcome,
+                        'branch': self.branch
                     })
                 except AttributeError:
                     pass

--- a/pytest_tinybird/tinybird.py
+++ b/pytest_tinybird/tinybird.py
@@ -49,6 +49,7 @@ class TinybirdReport:
                     report.append({
                         'date': now,
                         'commit': self.commit,
+                        'branch': self.branch,
                         'job_id': self.job_id,
                         'job_url': self.job_url,
                         'job_name': self.job_name,
@@ -56,8 +57,7 @@ class TinybirdReport:
                         'test_name': test.head_line,
                         'test_part': test.when,
                         'duration': test.duration,
-                        'outcome': test.outcome,
-                        'branch': self.branch
+                        'outcome': test.outcome
                     })
                 except AttributeError:
                     pass


### PR DESCRIPTION
This PR adds `branch` property to the report data of each test we send to Tinybird.

**Why is this useful?**
Most of the times, commit SHA is not something we remember from the top of our mind, but branch names are.
So, for example, if we have a summary of the latest X jobs run, and there's one that has a spike in terms of time, it'd be much easier to find the merge request by the branch name than a specific commit.

Commit SHA is useful along with the branch name to see the specific commit that caused that change in the test executions.

That's my humble opinion, but let's see if you think this is useful 😁 .

**Implementation**

GitLab branch name variables are a bit weird, and they are not unified as opposed to GitHub.

If the job is triggered from a Merge Request, `CI_MERGE_REQUEST_SOURCE_BRANCH_NAME` will be available, or `CI_COMMIT_BRANCH` otherwise.

GitHub branch name is located in the `ref_name` variable inside `github` context variable. So I decided to add that value to the `CI_COMMIT_BRANCH` env variable.