### PR TITLE
Add retry mechanism for sending tinybird requests

### DIFF
--- a/pytest_tinybird/tinybird.py
+++ b/pytest_tinybird/tinybird.py
@@ -77,12 +77,12 @@ class TinybirdReport:
                     timeout=self.timeout
                 )
                 if response.status_code in [200, 202]:
-                    break 
-                log.error("Error while uploading to tinybird %s (Attempt %s/%s)", 
-                         response.status_code, attempt + 1, self.retries + 1)
+                    break
+                log.error("Error while uploading to tinybird %s (Attempt %s/%s)",
+                          response.status_code, attempt + 1, self.retries + 1)
             except requests.exceptions.RequestException as e:
-                log.error("Request failed: %s (Attempt %s/%s)", 
-                         e, attempt + 1, self.retries + 1)
+                log.error("Request failed: %s (Attempt %s/%s)",
+                          e, attempt + 1, self.retries + 1)
             if attempt < self.retries:
                 time.sleep(2 ** attempt)
         else:


### PR DESCRIPTION
Sometimes, when sending the pytest results to tinybird, there is a read-timeout:
`requests.exceptions.ReadTimeout: HTTPSConnectionPool(host='api.tinybird.co', port=443): Read timed out. (read timeout=2)`

We could increase the timeout, but it is not always necessary. Retrying the request usually resolves this issue. This is also something that was suggested by Tinybird support for the same issue in different contexts.

Therefore, this PR adds an option to do retries directly in the plugin instead of re-running the pipeline. It includes an exponential backoff for each retry. The backoff is hard-coded to be 2^retry, to not introduce more environment parameters to the already many existing ones.

It also adds a test case for this new behavior.