### PR TITLE
Add optional report parameters for multi-repository/multi-workflow uses

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,9 @@ There are also additional optional values that can be set for multi-repository a
 }
 ```
 
+To use these, you will need to set the `CI_REPOSITORY_NAME` and `CI_WORKFLOW_NAME` environment variables respectively.
+
+
 When a `report` object is first sent to Tinybird, a Data Source with the following definition and schema is created:
 
 ```sql

--- a/README.md
+++ b/README.md
@@ -82,6 +82,15 @@ The `pytest-tinybird` plugin creates and sends `report` objects via the [Events 
 }
 ```
 
+There are also additional optional values that can be set for multi-repository and multi-workflow setups (e.g., in GitHub Actions):
+
+```
+{
+    'repository': self.repository
+    'workflow': self.workflow
+}
+```
+
 When a `report` object is first sent to Tinybird, a Data Source with the following definition and schema is created:
 
 ```sql


### PR DESCRIPTION
# Problem

In our use case we have multiple workflows running in multiple GitHub repositories and we want to keep that information inside of our data for future reference. (The same tests run in different repositories/workflows)

To do that, currently we need to create separate datasources for all GHA workflows and then merge them into one big materialized view which adds the repository and workflow information. 
This is limiting when wanting to add a lot of new workflows to our setup. Every new workflow needs a new datasource and a new materialization into this materialized view. This also, after some time looks unwieldy inside the data flow view in the tinybird webapp. 

# Proposed solution

We can immediately send the reports containing that added information (repository and workflow) and push it into the materialized datasource directly. 

To preserve compatibility with previous usages of this plugin those additional fields can remain optional and will only be included if the corresponding environment variables have been set.

